### PR TITLE
Update node-pty to v1.1.0-beta34

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
-    "node-pty": "^1.0.0",
+    "node-pty": "1.1.0-beta34",
     "nuxt": "^3.17.7",
     "pinia": "^3.0.3",
     "simple-git": "^3.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       node-pty:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: 1.1.0-beta34
+        version: 1.1.0-beta34
       nuxt:
         specifier: ^3.17.7
         version: 3.17.7(@parcel/watcher@2.5.1)(@types/node@24.0.13)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.0)(terser@5.43.1)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.1(typescript@5.8.3))(yaml@2.8.0)
@@ -4099,9 +4099,6 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nan@2.23.0:
-    resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4178,8 +4175,8 @@ packages:
   node-mock-http@1.0.1:
     resolution: {integrity: sha512-0gJJgENizp4ghds/Ywu2FCmcRsgBTmRQzYPZm61wy+Em2sBarSka0OhQS5huLBg6od1zkNpnWMCZloQDFVvOMQ==}
 
-  node-pty@1.0.0:
-    resolution: {integrity: sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==}
+  node-pty@1.1.0-beta34:
+    resolution: {integrity: sha512-RraDtX9RS1G1I5iO7e4YIOIA4arzd4ZVCD4mZr7+szaNupoTg9fxDCRr0EanqS0Qlzgm3PIdHNbPmblJguJuyg==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -10375,8 +10372,6 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nan@2.23.0: {}
-
   nanoid@3.3.11: {}
 
   nanoid@5.1.5: {}
@@ -10522,9 +10517,9 @@ snapshots:
 
   node-mock-http@1.0.1: {}
 
-  node-pty@1.0.0:
+  node-pty@1.1.0-beta34:
     dependencies:
-      nan: 2.23.0
+      node-addon-api: 7.1.1
 
   node-releases@2.0.19: {}
 


### PR DESCRIPTION
## Summary
- Updates node-pty from v1.0.0 to v1.1.0-beta34
- This beta version includes various improvements and bug fixes
- Native bindings have been rebuilt and tested

## Test plan
- [x] Updated package.json dependency
- [x] Ran `pnpm install` to update lockfile
- [x] Rebuilt native bindings with `npm rebuild`
- [x] All tests pass (`pnpm test`)
- [x] Development server runs without issues

## Notes
- Minimum Node.js version requirement remains at v16
- The PR mentioned (https://github.com/homebridge/node-pty-prebuilt-multiarch/pull/59) is for a different package (node-pty-prebuilt-multiarch) that adds Node.js 24 support, but the official microsoft/node-pty@1.1.0-beta34 we're using supports Node.js 16+

🤖 Generated with [Claude Code](https://claude.ai/code)