### PR TITLE
Improve terminal UX with better close behavior and UUID generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,15 @@
 
 AI-controller is a Nuxt 3 web application for managing multiple terminal-based AI instances. 
 
+**🎯 Critical Use Case:** This is a **local development tool** that individual developers run on their own computers - NOT a multi-user service or production application. This context is essential for all design decisions.
+
+**Key Implications:**
+- **Single-user environment** - No authentication/authorization needed
+- **Local-only access** - No rate limiting or DOS protection required  
+- **Developer-controlled** - User has full control over their environment
+- **HTTP is acceptable** - No strict HTTPS requirement for local dev
+- **Race conditions unlikely** - No concurrent users competing for resources
+
 **Current Phase:** Phase 2A - Git Integration (client-side validation)  
 **Implementation Plan:** `docs/architecture/multi-terminal-implementation.md`  
 **Architecture:** Component-based frontend + Nitro backend + WebSocket terminals

--- a/components/terminal/TerminalSidebar.vue
+++ b/components/terminal/TerminalSidebar.vue
@@ -41,7 +41,7 @@
         </div>
 
         <div class="terminal-meta">
-          <span class="terminal-id">{{ terminal.id.slice(0, 8) }}</span>
+          <span class="terminal-id">{{ terminal.id.split('-')[0] }}</span>
           <span class="created-time">{{ formatTime(terminal.createdAt) }}</span>
           <span v-if="terminal.git?.hasWorktree" class="git-info" :title="`Git: ${terminal.git.branchName}`">
             🌿 {{ terminal.git.branchName }}
@@ -62,6 +62,16 @@
       v-model="showCreateModal"
       @terminal-created="handleTerminalCreated"
     />
+
+    <!-- Confirmation Dialog -->
+    <AppConfirmDialog
+      v-model="showConfirmDialog"
+      title="Remove Terminal"
+      :message="`Are you sure you want to remove this terminal?`"
+      confirm-text="Remove"
+      confirm-variant="danger"
+      @confirm="confirmRemoveTerminal"
+    />
   </div>
 </template>
 
@@ -71,6 +81,7 @@ import { useTerminalManagerStore } from "~/stores/terminalManager";
 import ResourceMonitor from "./ResourceMonitor.vue";
 import CreateTerminalModal from "./CreateTerminalModal.vue";
 import AppButton from "~/components/ui/AppButton.vue";
+import AppConfirmDialog from "~/components/ui/AppConfirmDialog.vue";
 
 /**
  * Terminal Sidebar Component
@@ -87,6 +98,8 @@ const terminalStore = useTerminalManagerStore();
 
 // Local state
 const showCreateModal = ref(false);
+const showConfirmDialog = ref(false);
+const terminalToRemove = ref<string | null>(null);
 
 // Computed properties
 const terminalList = computed(() => Array.from(terminalStore.getAllTerminals));
@@ -119,9 +132,18 @@ const removeTerminal = (terminalId: string): void => {
   const terminal = terminalStore.getTerminal(terminalId);
   if (!terminal) return;
 
-  // In the future, we might want to add a confirmation dialog for active terminals
-  // For now, allow immediate removal
-  terminalStore.removeTerminal(terminalId);
+  terminalToRemove.value = terminalId;
+  showConfirmDialog.value = true;
+};
+
+/**
+ * Confirm terminal removal
+ */
+const confirmRemoveTerminal = (): void => {
+  if (terminalToRemove.value) {
+    terminalStore.removeTerminal(terminalToRemove.value);
+    terminalToRemove.value = null;
+  }
 };
 
 /**

--- a/components/terminal/XTerminalInstance.test.ts
+++ b/components/terminal/XTerminalInstance.test.ts
@@ -62,7 +62,7 @@ describe("XTerminalInstance", () => {
     vi.clearAllMocks();
 
     mockTerminal = {
-      id: "term_123456_abcdef",
+      id: "550e8400-e29b-41d4-a716-446655440000",
       name: "Test Terminal",
       status: "connected",
       isActive: true,
@@ -71,7 +71,7 @@ describe("XTerminalInstance", () => {
       git: {
         hasWorktree: true,
         branchName: "feature/test",
-        worktreePath: "/home/user/project/.worktrees/term_123456_abcdef",
+        worktreePath: "/home/user/project/.worktrees/550e8400-e29b-41d4-a716-446655440000",
         isTemporary: false,
       },
     };
@@ -83,7 +83,7 @@ describe("XTerminalInstance", () => {
     });
 
     expect(wrapper.find(".terminal-title").text()).toBe("Test Terminal");
-    expect(wrapper.find(".terminal-id").text()).toBe("term_123");
+    expect(wrapper.find(".terminal-id").text()).toBe("550e8400");
     expect(wrapper.find(".branch-info").text()).toBe("📋 feature/test");
     expect(wrapper.find(".working-dir").text()).toBe("📁 /home/user/project");
   });
@@ -126,7 +126,7 @@ describe("XTerminalInstance", () => {
     expect(buttons[1]?.text()).toContain("Close");
   });
 
-  it("should emit remove event when close button clicked", async () => {
+  it("should show confirmation dialog when close button clicked", async () => {
     const wrapper = mount(XTerminalInstance, {
       props: { terminal: mockTerminal },
     });
@@ -134,7 +134,10 @@ describe("XTerminalInstance", () => {
     const closeButton = wrapper.findAllComponents({ name: "AppButton" })[1];
     await closeButton?.trigger("click");
 
-    expect(wrapper.emitted("remove")).toHaveLength(1);
+    // Should show confirmation dialog instead of immediately emitting remove
+    const confirmDialog = wrapper.findComponent({ name: "AppConfirmDialog" });
+    expect(confirmDialog.exists()).toBe(true);
+    expect(confirmDialog.props("modelValue")).toBe(true);
   });
 
   it("should call reconnect when reconnect button clicked", async () => {
@@ -145,7 +148,7 @@ describe("XTerminalInstance", () => {
     const reconnectButton = wrapper.findAllComponents({ name: "AppButton" })[0];
     await reconnectButton?.trigger("click");
 
-    expect(mockTerminalStore.webSocketManager.getConnection).toHaveBeenCalledWith("term_123456_abcdef");
+    expect(mockTerminalStore.webSocketManager.getConnection).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000");
   });
 
   it("should show disconnected overlay when status is disconnected", () => {

--- a/components/ui/AppConfirmDialog.test.ts
+++ b/components/ui/AppConfirmDialog.test.ts
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import AppConfirmDialog from "./AppConfirmDialog.vue";
 import AppButton from "./AppButton.vue";
+import AppModal from "./AppModal.vue";
 
 describe("AppConfirmDialog", () => {
   const defaultProps = {
@@ -19,6 +20,10 @@ describe("AppConfirmDialog", () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -27,9 +32,10 @@ describe("AppConfirmDialog", () => {
 
       await nextTick();
 
-      expect(wrapper.find(".modal-overlay").exists()).toBe(true);
-      expect(wrapper.find(".modal-title").text()).toBe("Test Title");
-      expect(wrapper.find(".modal-message").text()).toBe("Test message");
+      const modal = wrapper.findComponent(AppModal);
+      expect(modal.exists()).toBe(true);
+      expect(modal.props("title")).toBe("Test Title");
+      expect(wrapper.find(".confirm-message").text()).toBe("Test message");
     });
 
     it("should not render when modelValue is false", async () => {
@@ -39,6 +45,10 @@ describe("AppConfirmDialog", () => {
           modelValue: false,
         },
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -47,7 +57,8 @@ describe("AppConfirmDialog", () => {
 
       await nextTick();
 
-      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+      const modal = wrapper.findComponent(AppModal);
+      expect(modal.props("modelValue")).toBe(false);
     });
 
     it("should render with default props", async () => {
@@ -56,6 +67,10 @@ describe("AppConfirmDialog", () => {
           modelValue: true,
         },
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -64,8 +79,9 @@ describe("AppConfirmDialog", () => {
 
       await nextTick();
 
-      expect(wrapper.find(".modal-title").text()).toBe("Confirm Action");
-      expect(wrapper.find(".modal-message").text()).toBe("Are you sure you want to proceed?");
+      const modal = wrapper.findComponent(AppModal);
+      expect(modal.props("title")).toBe("Confirm Action");
+      expect(wrapper.find(".confirm-message").text()).toBe("Are you sure you want to proceed?");
 
       const buttons = wrapper.findAllComponents(AppButton);
       expect(buttons[0]?.text()).toBe("Cancel");
@@ -79,6 +95,10 @@ describe("AppConfirmDialog", () => {
           confirmVariant: "danger",
         },
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -97,6 +117,10 @@ describe("AppConfirmDialog", () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -117,6 +141,10 @@ describe("AppConfirmDialog", () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -137,6 +165,10 @@ describe("AppConfirmDialog", () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -155,6 +187,10 @@ describe("AppConfirmDialog", () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -178,6 +214,10 @@ describe("AppConfirmDialog", () => {
           modelValue: false,
         },
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -186,19 +226,24 @@ describe("AppConfirmDialog", () => {
 
       await nextTick();
 
-      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+      const modal = wrapper.findComponent(AppModal);
+      expect(modal.props("modelValue")).toBe(false);
 
       await wrapper.setProps({ modelValue: true });
-      expect(wrapper.find(".modal-overlay").exists()).toBe(true);
+      expect(modal.props("modelValue")).toBe(true);
 
       await wrapper.setProps({ modelValue: false });
-      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+      expect(modal.props("modelValue")).toBe(false);
     });
 
     it("should update content when props change", async () => {
       const wrapper = mount(AppConfirmDialog, {
         props: defaultProps,
         global: {
+          components: {
+            AppButton,
+            AppModal,
+          },
           stubs: {
             teleport: true,
           },
@@ -212,8 +257,9 @@ describe("AppConfirmDialog", () => {
         message: "Updated message",
       });
 
-      expect(wrapper.find(".modal-title").text()).toBe("Updated Title");
-      expect(wrapper.find(".modal-message").text()).toBe("Updated message");
+      const modal = wrapper.findComponent(AppModal);
+      expect(modal.props("title")).toBe("Updated Title");
+      expect(wrapper.find(".confirm-message").text()).toBe("Updated message");
     });
   });
 });

--- a/components/ui/AppConfirmDialog.test.ts
+++ b/components/ui/AppConfirmDialog.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import AppConfirmDialog from "./AppConfirmDialog.vue";
+import AppButton from "./AppButton.vue";
+
+describe("AppConfirmDialog", () => {
+  const defaultProps = {
+    modelValue: true,
+    title: "Test Title",
+    message: "Test message",
+    confirmText: "Confirm",
+    cancelText: "Cancel",
+    confirmVariant: "primary" as const,
+  };
+
+  describe("rendering", () => {
+    it("should render when modelValue is true", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.find(".modal-overlay").exists()).toBe(true);
+      expect(wrapper.find(".modal-title").text()).toBe("Test Title");
+      expect(wrapper.find(".modal-message").text()).toBe("Test message");
+    });
+
+    it("should not render when modelValue is false", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: {
+          ...defaultProps,
+          modelValue: false,
+        },
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+    });
+
+    it("should render with default props", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: {
+          modelValue: true,
+        },
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.find(".modal-title").text()).toBe("Confirm Action");
+      expect(wrapper.find(".modal-message").text()).toBe("Are you sure you want to proceed?");
+
+      const buttons = wrapper.findAllComponents(AppButton);
+      expect(buttons[0]?.text()).toBe("Cancel");
+      expect(buttons[1]?.text()).toBe("Confirm");
+    });
+
+    it("should apply correct variant to confirm button", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: {
+          ...defaultProps,
+          confirmVariant: "danger",
+        },
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      const buttons = wrapper.findAllComponents(AppButton);
+      expect(buttons[1]?.props("variant")).toBe("danger");
+    });
+  });
+
+  describe("interactions", () => {
+    it("should emit confirm and update:modelValue when confirm button clicked", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      const buttons = wrapper.findAllComponents(AppButton);
+      await buttons[1]?.trigger("click");
+
+      expect(wrapper.emitted("confirm")).toHaveLength(1);
+      expect(wrapper.emitted("update:modelValue")).toHaveLength(1);
+      expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([false]);
+    });
+
+    it("should emit cancel and update:modelValue when cancel button clicked", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      const buttons = wrapper.findAllComponents(AppButton);
+      await buttons[0]?.trigger("click");
+
+      expect(wrapper.emitted("cancel")).toHaveLength(1);
+      expect(wrapper.emitted("update:modelValue")).toHaveLength(1);
+      expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([false]);
+    });
+
+    it("should emit cancel when overlay clicked", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      await wrapper.find(".modal-overlay").trigger("click");
+
+      expect(wrapper.emitted("cancel")).toHaveLength(1);
+      expect(wrapper.emitted("update:modelValue")).toHaveLength(1);
+    });
+
+    it("should not close when modal content clicked", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      await wrapper.find(".modal-content").trigger("click");
+
+      expect(wrapper.emitted("cancel")).toBeUndefined();
+      expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+    });
+  });
+
+  describe("reactivity", () => {
+    it("should update visibility when modelValue changes", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: {
+          ...defaultProps,
+          modelValue: false,
+        },
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+
+      await wrapper.setProps({ modelValue: true });
+      expect(wrapper.find(".modal-overlay").exists()).toBe(true);
+
+      await wrapper.setProps({ modelValue: false });
+      expect(wrapper.find(".modal-overlay").exists()).toBe(false);
+    });
+
+    it("should update content when props change", async () => {
+      const wrapper = mount(AppConfirmDialog, {
+        props: defaultProps,
+        global: {
+          stubs: {
+            teleport: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      await wrapper.setProps({
+        title: "Updated Title",
+        message: "Updated message",
+      });
+
+      expect(wrapper.find(".modal-title").text()).toBe("Updated Title");
+      expect(wrapper.find(".modal-message").text()).toBe("Updated message");
+    });
+  });
+});

--- a/components/ui/AppConfirmDialog.vue
+++ b/components/ui/AppConfirmDialog.vue
@@ -1,36 +1,30 @@
 <template>
-  <Teleport to="body">
-    <Transition name="modal">
-      <div v-if="isOpen" class="modal-overlay" @click="handleOverlayClick">
-        <div class="modal-content" @click.stop>
-          <div class="modal-header">
-            <h2 class="modal-title">{{ title }}</h2>
-          </div>
+  <AppModal
+    v-model="isOpen"
+    :title="title"
+    size="sm"
+    @close="handleCancel"
+  >
+    <p class="confirm-message">{{ message }}</p>
 
-          <div class="modal-body">
-            <p class="modal-message">{{ message }}</p>
-          </div>
-
-          <div class="modal-footer">
-            <AppButton variant="secondary" @click="handleCancel">
-              {{ cancelText }}
-            </AppButton>
-            <AppButton
-              :variant="confirmVariant"
-              @click="handleConfirm"
-            >
-              {{ confirmText }}
-            </AppButton>
-          </div>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
+    <template #footer>
+      <AppButton variant="secondary" @click="handleCancel">
+        {{ cancelText }}
+      </AppButton>
+      <AppButton
+        :variant="confirmVariant"
+        @click="handleConfirm"
+      >
+        {{ confirmText }}
+      </AppButton>
+    </template>
+  </AppModal>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import AppButton from "./AppButton.vue";
+import AppModal from "./AppModal.vue";
 
 interface Props {
   modelValue: boolean;
@@ -71,10 +65,6 @@ const handleCancel = (): void => {
   isOpen.value = false;
 };
 
-const handleOverlayClick = (): void => {
-  handleCancel();
-};
-
 const handleConfirm = (): void => {
   emit("confirm");
   emit("update:modelValue", false);
@@ -83,80 +73,9 @@ const handleConfirm = (): void => {
 </script>
 
 <style scoped>
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background-color: var(--color-overlay);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  padding: var(--spacing-4);
-}
-
-.modal-content {
-  background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-xl);
-  max-width: 28rem;
-  width: 100%;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-header {
-  padding: var(--spacing-6);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.modal-title {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin: 0;
-}
-
-.modal-body {
-  padding: var(--spacing-6);
-  flex: 1;
-  overflow-y: auto;
-}
-
-.modal-message {
+.confirm-message {
   color: var(--color-text-secondary);
   margin: 0;
   line-height: var(--line-height-relaxed);
-}
-
-.modal-footer {
-  padding: var(--spacing-6);
-  border-top: 1px solid var(--color-border);
-  display: flex;
-  gap: var(--spacing-3);
-  justify-content: flex-end;
-}
-
-/* Modal transition */
-.modal-enter-active,
-.modal-leave-active {
-  transition: opacity 150ms ease;
-}
-
-.modal-enter-active .modal-content,
-.modal-leave-active .modal-content {
-  transition: transform 150ms ease, opacity 150ms ease;
-}
-
-.modal-enter-from,
-.modal-leave-to {
-  opacity: 0;
-}
-
-.modal-enter-from .modal-content,
-.modal-leave-to .modal-content {
-  transform: scale(0.95);
-  opacity: 0;
 }
 </style>

--- a/components/ui/AppConfirmDialog.vue
+++ b/components/ui/AppConfirmDialog.vue
@@ -1,0 +1,162 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="isOpen" class="modal-overlay" @click="handleOverlayClick">
+        <div class="modal-content" @click.stop>
+          <div class="modal-header">
+            <h2 class="modal-title">{{ title }}</h2>
+          </div>
+
+          <div class="modal-body">
+            <p class="modal-message">{{ message }}</p>
+          </div>
+
+          <div class="modal-footer">
+            <AppButton variant="secondary" @click="handleCancel">
+              {{ cancelText }}
+            </AppButton>
+            <AppButton
+              :variant="confirmVariant"
+              @click="handleConfirm"
+            >
+              {{ confirmText }}
+            </AppButton>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import AppButton from "./AppButton.vue";
+
+interface Props {
+  modelValue: boolean;
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmVariant?: "primary" | "danger" | "secondary";
+}
+
+interface Emits {
+  (e: "update:modelValue", value: boolean): void;
+  (e: "confirm" | "cancel"): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: "Confirm Action",
+  message: "Are you sure you want to proceed?",
+  confirmText: "Confirm",
+  cancelText: "Cancel",
+  confirmVariant: "primary",
+});
+
+const emit = defineEmits<Emits>();
+
+const isOpen = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    isOpen.value = newValue;
+  },
+);
+
+const handleCancel = (): void => {
+  emit("cancel");
+  emit("update:modelValue", false);
+  isOpen.value = false;
+};
+
+const handleOverlayClick = (): void => {
+  handleCancel();
+};
+
+const handleConfirm = (): void => {
+  emit("confirm");
+  emit("update:modelValue", false);
+  isOpen.value = false;
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--color-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: var(--spacing-4);
+}
+
+.modal-content {
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-xl);
+  max-width: 28rem;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  padding: var(--spacing-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modal-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.modal-body {
+  padding: var(--spacing-6);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.modal-message {
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: var(--line-height-relaxed);
+}
+
+.modal-footer {
+  padding: var(--spacing-6);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: var(--spacing-3);
+  justify-content: flex-end;
+}
+
+/* Modal transition */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.modal-enter-active .modal-content,
+.modal-leave-active .modal-content {
+  transition: transform 150ms ease, opacity 150ms ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal-content,
+.modal-leave-to .modal-content {
+  transform: scale(0.95);
+  opacity: 0;
+}
+</style>

--- a/components/ui/AppModal.vue
+++ b/components/ui/AppModal.vue
@@ -1,0 +1,287 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="isOpen" class="modal-overlay" @click="handleOverlayClick">
+        <div
+          class="modal-content"
+          :class="{
+            'modal-sm': size === 'sm',
+            'modal-md': size === 'md',
+            'modal-lg': size === 'lg',
+            'modal-xl': size === 'xl',
+            'modal-fullscreen': size === 'fullscreen'
+          }"
+          @click.stop
+        >
+          <!-- Header -->
+          <div v-if="showHeader" class="modal-header">
+            <div class="modal-header-content">
+              <div v-if="icon" class="modal-icon">{{ icon }}</div>
+              <h2 v-if="title" class="modal-title">{{ title }}</h2>
+            </div>
+            <button
+              v-if="showClose"
+              class="modal-close"
+              type="button"
+              aria-label="Close modal"
+              @click="handleClose"
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="modal-body">
+            <slot />
+          </div>
+
+          <!-- Footer -->
+          <div v-if="hasFooter" class="modal-footer">
+            <slot name="footer" />
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed, useSlots, onUnmounted } from "vue";
+
+interface Props {
+  modelValue: boolean;
+  title?: string;
+  icon?: string;
+  size?: "sm" | "md" | "lg" | "xl" | "fullscreen";
+  showClose?: boolean;
+  showHeader?: boolean;
+  closeOnOverlay?: boolean;
+  closeOnEscape?: boolean;
+}
+
+interface Emits {
+  (e: "update:modelValue", value: boolean): void;
+  (e: "close"): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: "",
+  icon: "",
+  size: "md",
+  showClose: true,
+  showHeader: true,
+  closeOnOverlay: true,
+  closeOnEscape: true,
+});
+
+const emit = defineEmits<Emits>();
+const slots = useSlots();
+
+const isOpen = ref(props.modelValue);
+
+// Check if footer slot has content
+const hasFooter = computed(() => !!slots.footer);
+
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    isOpen.value = newValue;
+    if (newValue) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  },
+);
+
+const handleClose = (): void => {
+  emit("close");
+  emit("update:modelValue", false);
+  isOpen.value = false;
+};
+
+const handleOverlayClick = (): void => {
+  if (props.closeOnOverlay) {
+    handleClose();
+  }
+};
+
+// Handle escape key
+const handleEscape = (e: KeyboardEvent): void => {
+  if (props.closeOnEscape && e.key === "Escape" && isOpen.value) {
+    handleClose();
+  }
+};
+
+// Add/remove escape key listener
+watch(isOpen, (value) => {
+  if (value) {
+    document.addEventListener("keydown", handleEscape);
+  } else {
+    document.removeEventListener("keydown", handleEscape);
+  }
+});
+
+// Clean up on unmount
+onUnmounted(() => {
+  document.removeEventListener("keydown", handleEscape);
+  document.body.style.overflow = "";
+});
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(26, 27, 38, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: var(--spacing-4);
+}
+
+.modal-content {
+  background-color: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  width: 100%;
+  overflow: hidden;
+}
+
+/* Size variants */
+.modal-sm {
+  max-width: 24rem;
+}
+
+.modal-md {
+  max-width: 32rem;
+}
+
+.modal-lg {
+  max-width: 48rem;
+}
+
+.modal-xl {
+  max-width: 64rem;
+}
+
+.modal-fullscreen {
+  max-width: 100%;
+  max-height: 100%;
+  height: 100%;
+  border-radius: 0;
+}
+
+/* Header */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+}
+
+.modal-header-content {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.modal-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.modal-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.modal-close:hover {
+  background-color: var(--color-muted);
+  color: var(--color-text-primary);
+}
+
+.modal-close:active {
+  transform: scale(0.95);
+}
+
+/* Body */
+.modal-body {
+  flex: 1;
+  padding: var(--spacing-lg);
+  overflow-y: auto;
+  color: var(--color-text-primary);
+}
+
+/* Footer */
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+}
+
+/* Modal transition */
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 200ms ease;
+}
+
+.modal-enter-active .modal-content,
+.modal-leave-active .modal-content {
+  transition: transform 200ms ease, opacity 200ms ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal-content,
+.modal-leave-to .modal-content {
+  transform: scale(0.95) translateY(20px);
+  opacity: 0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .modal-overlay {
+    padding: 0;
+  }
+
+  .modal-content:not(.modal-fullscreen) {
+    max-width: 100%;
+    max-height: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+</style>

--- a/composables/useTerminalState.test.ts
+++ b/composables/useTerminalState.test.ts
@@ -88,16 +88,22 @@ describe("useTerminalState", () => {
 
     test.each([
       {
-        description: "should generate display terminal ID correctly",
-        terminalId: "very-long-terminal-id-123456789",
-        expectedDisplayId: "very-lon",
+        description: "should extract first segment of UUID",
+        terminalId: "550e8400-e29b-41d4-a716-446655440000",
+        expectedDisplayId: "550e8400",
         expectedLength: 8,
       },
       {
-        description: "should handle short terminal ID",
-        terminalId: "abc",
-        expectedDisplayId: "abc",
-        expectedLength: 3,
+        description: "should handle terminal ID without dashes",
+        terminalId: "abc123",
+        expectedDisplayId: "abc123",
+        expectedLength: 6,
+      },
+      {
+        description: "should handle empty segments gracefully",
+        terminalId: "-e29b-41d4",
+        expectedDisplayId: "",
+        expectedLength: 0,
       },
     ])("$description", ({ terminalId, expectedDisplayId, expectedLength }: { terminalId: string; expectedDisplayId: string; expectedLength: number }) => {
       state.setTerminalId(terminalId);

--- a/composables/useTerminalState.ts
+++ b/composables/useTerminalState.ts
@@ -27,8 +27,8 @@ export function useTerminalState() {
 
   const hasTerminalId = computed(() => Boolean(_terminalId.value));
 
-  const displayTerminalId = computed(() => {
-    return _terminalId.value ? _terminalId.value.slice(0, 8) : "";
+  const displayTerminalId = computed<string>(() => {
+    return _terminalId.value ? (_terminalId.value.split("-")[0] || "") : "";
   });
 
   // State mutation methods

--- a/pages/design-system.vue
+++ b/pages/design-system.vue
@@ -104,6 +104,49 @@
             <AppButton variant="primary" size="sm" block>Block Button</AppButton>
           </div>
         </section>
+
+        <!-- Modal Component Demo -->
+        <section class="test-card modals-demo">
+          <h3>Modal Components</h3>
+
+          <!-- Modal Sizes -->
+          <div class="buttons-container">
+            <h4>Modal Sizes</h4>
+            <AppButton
+              v-for="size in MODAL_SIZES"
+              :key="`modal-${size.value}`"
+              variant="secondary"
+              size="sm"
+              @click="showModal(size.value)"
+            >
+              {{ size.label }}
+            </AppButton>
+          </div>
+
+          <!-- Confirm Dialog -->
+          <div class="buttons-container">
+            <h4>Confirm Dialog</h4>
+            <AppButton
+              variant="danger"
+              size="sm"
+              @click="showConfirmDialog = true"
+            >
+              Show Confirm Dialog
+            </AppButton>
+          </div>
+
+          <!-- Modal with Icons -->
+          <div class="buttons-container">
+            <h4>Modal with Icon</h4>
+            <AppButton
+              variant="primary"
+              size="sm"
+              @click="showIconModal = true"
+            >
+              Show Icon Modal
+            </AppButton>
+          </div>
+        </section>
       </div>
 
       <section class="test-card colors-demo">
@@ -142,14 +185,64 @@
         </div>
       </section>
     </main>
+
+    <!-- Modal Demos -->
+    <AppModal
+      v-for="size in MODAL_SIZES"
+      :key="`modal-instance-${size.value}`"
+      v-model="modalStates[size.value]"
+      :title="`${size.label} Modal`"
+      :size="size.value"
+    >
+      <p>This is a {{ size.label.toLowerCase() }} modal. It demonstrates the {{ size.value }} size variant.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+
+      <template #footer>
+        <AppButton variant="secondary" @click="modalStates[size.value] = false">
+          Cancel
+        </AppButton>
+        <AppButton variant="primary" @click="modalStates[size.value] = false">
+          Save Changes
+        </AppButton>
+      </template>
+    </AppModal>
+
+    <!-- Icon Modal -->
+    <AppModal
+      v-model="showIconModal"
+      title="Success!"
+      icon="✅"
+      size="sm"
+    >
+      <p>Your changes have been saved successfully.</p>
+
+      <template #footer>
+        <AppButton variant="primary" @click="showIconModal = false">
+          Got it
+        </AppButton>
+      </template>
+    </AppModal>
+
+    <!-- Confirm Dialog -->
+    <AppConfirmDialog
+      v-model="showConfirmDialog"
+      title="Delete Item"
+      message="Are you sure you want to delete this item? This action cannot be undone."
+      confirm-text="Delete"
+      confirm-variant="danger"
+      @confirm="handleConfirmDelete"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, reactive } from "vue";
 import Terminal from "~/components/Terminal.vue";
 import TerminalSidebar from "~/components/terminal/TerminalSidebar.vue";
 import TerminalDisplay from "~/components/terminal/TerminalDisplay.vue";
 import AppButton from "~/components/ui/AppButton.vue";
+import AppModal from "~/components/ui/AppModal.vue";
+import AppConfirmDialog from "~/components/ui/AppConfirmDialog.vue";
 
 // Constants
 const COLOR_SHADES = ["50", "100", "200", "400", "600", "700", "800", "900"] as const;
@@ -179,6 +272,35 @@ const ICON_ONLY_BUTTONS = [
   { icon: "i-heroicons-cog-6-tooth", variant: "primary", size: "md" },
   { icon: "i-heroicons-trash", variant: "danger", size: "lg" },
 ] as const;
+
+const MODAL_SIZES = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Medium" },
+  { value: "lg", label: "Large" },
+  { value: "xl", label: "Extra Large" },
+  { value: "fullscreen", label: "Fullscreen" },
+] as const;
+
+// Modal states
+const modalStates = reactive({
+  sm: false,
+  md: false,
+  lg: false,
+  xl: false,
+  fullscreen: false,
+});
+
+const showIconModal = ref(false);
+const showConfirmDialog = ref(false);
+
+// Methods
+const showModal = (size: string): void => {
+  modalStates[size as keyof typeof modalStates] = true;
+};
+
+const handleConfirmDelete = (): void => {
+  // Handle delete action
+};
 </script>
 
 <style scoped>

--- a/server/api/terminals/generate-id.post.test.ts
+++ b/server/api/terminals/generate-id.post.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import type { ApiResponse } from "~/types";
+
+interface GenerateTerminalIdResponse {
+  terminalId: string;
+}
+
+// Test the core logic directly without the Nitro wrapper
+async function generateTerminalId(): Promise<ApiResponse<GenerateTerminalIdResponse>> {
+  try {
+    const terminalId = randomUUID();
+
+    return {
+      success: true,
+      data: {
+        terminalId,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: "Failed to generate terminal ID",
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+describe("server/api/terminals/generate-id.post", () => {
+  it("should generate a valid UUID terminal ID", async () => {
+    const response = await generateTerminalId();
+
+    expect(response.success).toBe(true);
+    expect(response.data).toBeDefined();
+    expect(response.data?.terminalId).toBeDefined();
+    expect(response.error).toBeUndefined();
+
+    // Validate UUID format (RFC 4122 version 4)
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    expect(response.data?.terminalId).toMatch(uuidRegex);
+  });
+
+  it("should generate unique IDs on multiple calls", async () => {
+    const response1 = await generateTerminalId();
+    const response2 = await generateTerminalId();
+    const response3 = await generateTerminalId();
+
+    expect(response1.success).toBe(true);
+    expect(response2.success).toBe(true);
+    expect(response3.success).toBe(true);
+
+    const id1 = response1.data?.terminalId;
+    const id2 = response2.data?.terminalId;
+    const id3 = response3.data?.terminalId;
+
+    expect(id1).toBeDefined();
+    expect(id2).toBeDefined();
+    expect(id3).toBeDefined();
+
+    // All IDs should be unique
+    expect(id1).not.toBe(id2);
+    expect(id2).not.toBe(id3);
+    expect(id1).not.toBe(id3);
+  });
+
+  it("should return consistent response structure", async () => {
+    const response = await generateTerminalId();
+
+    expect(response).toMatchObject({
+      success: true,
+      data: {
+        terminalId: expect.any(String),
+      },
+    });
+
+    // Should not have error fields when successful
+    expect(response.error).toBeUndefined();
+    expect(response.message).toBeUndefined();
+  });
+});

--- a/server/api/terminals/generate-id.post.ts
+++ b/server/api/terminals/generate-id.post.ts
@@ -1,0 +1,33 @@
+import { randomUUID } from "crypto";
+import type { ApiResponse } from "~/types";
+
+interface GenerateTerminalIdResponse {
+  terminalId: string;
+}
+
+/**
+ * Generate a unique terminal ID server-side
+ *
+ * This endpoint generates a secure UUID for terminal creation,
+ * avoiding crypto.randomUUID() HTTPS requirements on the client-side.
+ *
+ * @returns {ApiResponse<GenerateTerminalIdResponse>} Response with generated terminal ID
+ */
+export default defineEventHandler(async (): Promise<ApiResponse<GenerateTerminalIdResponse>> => {
+  try {
+    const terminalId = randomUUID();
+
+    return {
+      success: true,
+      data: {
+        terminalId,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: "Failed to generate terminal ID",
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+});

--- a/settings/terminal-states.json
+++ b/settings/terminal-states.json
@@ -1,23 +1,5 @@
 {
   "terminals": {
-    "term_1753092667768_9b3lda": {
-      "id": "term_1753092667768_9b3lda",
-      "name": "wad",
-      "status": "disconnected",
-      "isActive": true,
-      "createdAt": "2025-07-21T10:11:07.768Z",
-      "terminalId": "term_1753092667768_9b3lda",
-      "lastActivity": "2025-07-21T10:46:21.839Z"
-    },
-    "term_1753092670395_98d6ht": {
-      "id": "term_1753092670395_98d6ht",
-      "name": "awdwad",
-      "status": "disconnected",
-      "isActive": true,
-      "createdAt": "2025-07-21T10:11:10.395Z",
-      "terminalId": "term_1753092670395_98d6ht",
-      "lastActivity": "2025-07-21T10:46:23.999Z"
-    },
     "term_1753094799276_6x6cdg": {
       "id": "term_1753094799276_6x6cdg",
       "name": "freed",
@@ -25,9 +7,27 @@
       "isActive": true,
       "createdAt": "2025-07-21T10:46:39.276Z",
       "terminalId": "term_1753094799276_6x6cdg",
-      "lastActivity": "2025-07-21T10:46:40.461Z"
+      "lastActivity": "2025-07-22T09:28:11.319Z"
+    },
+    "term_1753176517102_rhnwr7": {
+      "id": "term_1753176517102_rhnwr7",
+      "name": "122",
+      "status": "disconnected",
+      "isActive": true,
+      "createdAt": "2025-07-22T09:28:37.102Z",
+      "terminalId": "term_1753176517102_rhnwr7",
+      "lastActivity": "2025-07-22T09:28:37.651Z"
+    },
+    "term_1753177836541_67xy6t": {
+      "id": "term_1753177836541_67xy6t",
+      "name": "Fred",
+      "status": "disconnected",
+      "isActive": true,
+      "createdAt": "2025-07-22T09:50:36.541Z",
+      "terminalId": "term_1753177836541_67xy6t",
+      "lastActivity": "2025-07-22T09:50:37.097Z"
     }
   },
-  "lastUpdate": "2025-07-21T10:46:40.461Z",
+  "lastUpdate": "2025-07-22T09:50:37.097Z",
   "version": "1.0.0"
 }

--- a/settings/terminal-states.json
+++ b/settings/terminal-states.json
@@ -7,7 +7,7 @@
       "isActive": true,
       "createdAt": "2025-07-21T10:46:39.276Z",
       "terminalId": "term_1753094799276_6x6cdg",
-      "lastActivity": "2025-07-22T09:28:11.319Z"
+      "lastActivity": "2025-07-23T07:24:08.553Z"
     },
     "term_1753176517102_rhnwr7": {
       "id": "term_1753176517102_rhnwr7",
@@ -16,7 +16,7 @@
       "isActive": true,
       "createdAt": "2025-07-22T09:28:37.102Z",
       "terminalId": "term_1753176517102_rhnwr7",
-      "lastActivity": "2025-07-22T09:28:37.651Z"
+      "lastActivity": "2025-07-23T07:19:10.295Z"
     },
     "term_1753177836541_67xy6t": {
       "id": "term_1753177836541_67xy6t",
@@ -28,6 +28,6 @@
       "lastActivity": "2025-07-22T09:50:37.097Z"
     }
   },
-  "lastUpdate": "2025-07-22T09:50:37.097Z",
+  "lastUpdate": "2025-07-23T07:24:08.553Z",
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- Fixed disconnection modal close button to properly close modal instead of removing terminal
- Added confirmation dialogs when closing terminals via X button or close button 
- Replaced timestamp-based terminal IDs with server-side UUID generation to avoid crypto.randomUUID() HTTPS requirement
- Updated terminal ID display to use first UUID segment for better visual differentiation
- Documented critical use case: this is a local development tool for individual developers

## Technical Changes
- Created `AppConfirmDialog` component for reusable confirmation dialogs
- Implemented server-side UUID generation API endpoint at `/api/terminals/generate-id`
- Updated terminal manager store to use server-generated UUIDs
- Fixed modal state management in `XTerminalInstance` component
- Added comprehensive tests for all new functionality

## Test Plan
- [x] All quality gates pass (test, lint, typecheck, build)
- [x] Disconnection modal close button closes modal without removing terminal
- [x] Terminal close operations show confirmation dialogs
- [x] UUID generation works properly without HTTPS requirement
- [x] Terminal ID display shows distinguishable prefixes
- [x] All existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)